### PR TITLE
Fix package installation problems and refactor classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 *egg-info
 build
 venv
+.venv
 dist
 __pycache__
 .idea
 test-reports
+.github

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ adb --version
 Import the necessary modules:
 
 ```python
-from adb-pywrapper import AdbDevice, AdbResult, PullResult
+from adb_pywrapper import AdbDevice, AdbResult, PullResult
 ```
 
 ## Listing Connected Devices

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ adb --version
 Import the necessary modules:
 
 ```python
-from adb_pywrapper import AdbDevice, AdbResult, PullResult
+from adb_pywrapper.adb_device import AdbDevice
+from adb_pywrapper.adb_result import AdbResult
+from adb_pywrapper.pull_result import PullResult
 ```
 
 ## Listing Connected Devices

--- a/adb_pywrapper/__init__.py
+++ b/adb_pywrapper/__init__.py
@@ -5,19 +5,9 @@ from os import makedirs, environ
 from os.path import dirname, abspath, isdir, expanduser
 from sys import stdout
 
-from adb_pywrapper.adb_device import AdbDevice
-from adb_pywrapper.adb_result import AdbResult
-from adb_pywrapper.adb_screen_recorder import AdbScreenRecorder
-from adb_pywrapper.pull_result import PullResult
 
 logger = logging.getLogger(__name__)
 
-__all__ = [
-    'AdbResult',
-    'PullResult',
-    'AdbDevice',
-    'AdbScreenRecorder',
-]
 ###########################
 # ADB INITIALISATION CODE #
 ###########################

--- a/adb_pywrapper/adb_device.py
+++ b/adb_pywrapper/adb_device.py
@@ -5,7 +5,9 @@ from subprocess import CompletedProcess
 from time import sleep
 from typing import Optional
 
-from adb_pywrapper import logger, log_error_and_raise_exception, ADB_PATH, AdbResult, PullResult
+from adb_pywrapper import logger, log_error_and_raise_exception, ADB_PATH
+from adb_pywrapper.adb_result import AdbResult
+from adb_pywrapper.pull_result import PullResult
 
 
 class AdbDevice:

--- a/adb_pywrapper/adb_result.py
+++ b/adb_pywrapper/adb_result.py
@@ -1,0 +1,17 @@
+from subprocess import CompletedProcess
+
+
+class AdbResult:
+    def __init__(self, completed_adb_process: CompletedProcess):
+        self.completed_adb_process: CompletedProcess = completed_adb_process
+        self.stdout: str = completed_adb_process.stdout.decode()
+        self.stderr: str = completed_adb_process.stderr.decode()
+        self.success: bool = completed_adb_process.returncode == 0
+
+    def __str__(self) -> str:
+        return f'success : "{self.success}", ' \
+               f'stdout : "{self.stdout}", ' \
+               f'stderr : "{self.stderr}"'
+
+    def __repr__(self) -> str:
+        return self.__str__()

--- a/adb_pywrapper/adb_screen_recorder.py
+++ b/adb_pywrapper/adb_screen_recorder.py
@@ -2,7 +2,8 @@ import subprocess
 from time import sleep
 from uuid import uuid4
 
-from adb_pywrapper import log_error_and_raise_exception, logger, ADB_PATH, AdbDevice
+from adb_pywrapper import log_error_and_raise_exception, logger, ADB_PATH
+from adb_pywrapper.adb_device import AdbDevice
 
 
 class AdbScreenRecorder:

--- a/adb_pywrapper/adb_screen_recorder.py
+++ b/adb_pywrapper/adb_screen_recorder.py
@@ -1,0 +1,64 @@
+import subprocess
+from time import sleep
+from uuid import uuid4
+
+from adb_pywrapper import log_error_and_raise_exception, logger, ADB_PATH, AdbDevice
+
+
+class AdbScreenRecorder:
+    def __init__(self, device: AdbDevice, bit_rate: str = '8M'):
+        self.device = device
+        self._recording_process = None
+        self._recording_folder = f'/sdcard/{uuid4()}'
+        self._bit_rate = bit_rate
+        self.__enter__()
+
+    def __enter__(self):
+        # create recording folder:
+        self.device.shell(f'mkdir {self._recording_folder}')
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # stop recording if still in process
+        if self.is_recording():
+            self._recording_process.kill()
+        # remove files on device
+        self.device.shell(f'rm -rf {self._recording_folder}')
+
+    def is_recording(self):
+        return self._recording_process is not None and self._recording_process.poll() is None
+
+    def start_recording(self):
+        if not self.is_recording():
+            arguments = f'{ADB_PATH} {self.device.device_command}shell'.split(' ')
+            loop = f'i=1; while true; do screenrecord --bit-rate {self._bit_rate} {self._recording_folder}/$i.mp4; let i=i+1; done'
+            arguments.append(loop)
+            logger.info(f'executing adb command: {arguments}')
+            self._recording_process = subprocess.Popen(arguments)
+
+    def _screenrecord_process_active_on_device(self):
+        return '' != self.device.shell('ps -A | grep screenrecord').stdout
+
+    def stop_recording(self, output_folder: str) -> [str]:
+        if not self.is_recording():
+            logger.warning(f"Recording was stopped but the recorder wasn't started")
+            return None
+        # Stop background process
+        logger.info('Stopping screen recorder...')
+        self._recording_process.terminate()
+        while self._screenrecord_process_active_on_device():
+            sleep(0.2)
+        self._recording_process = None
+        # collect recordings
+        video_files = [f'{self._recording_folder}/{file_name}' for file_name in
+                       self.device.ls(self._recording_folder)]
+        logger.info(f'Copying video files: {video_files}')
+        pull_results = self.device.pull_multi(video_files, output_folder)
+        failures = [pull_result for pull_result in pull_results if not pull_result.success]
+        if len(failures) > 0:
+            msg = f"Failed to pull file(s) {[failure.path for failure in failures]}"
+            log_error_and_raise_exception(logger, msg)
+        # clean up recordings on device
+        for video_file in video_files:
+            self.device.shell(f'rm -f {video_file}')
+        return [pull_result.path for pull_result in pull_results]  # pulled files

--- a/adb_pywrapper/pull_result.py
+++ b/adb_pywrapper/pull_result.py
@@ -1,0 +1,24 @@
+import os
+
+from adb_pywrapper import AdbResult
+
+
+class PullResult:
+    """
+    A class to represent the result of an adb pull. it contains three properties:
+        path: the path on which the pulled file should be available if the pull was successful
+        completed_adb_process: the result of the completed adb process
+        success: True if the pull was successful and the file in path exists
+    """
+
+    def __init__(self, result_path: str, adb_result: AdbResult):
+        self.completed_adb_process = adb_result
+        self.path = result_path
+        self.success = os.path.exists(result_path)
+
+    def __str__(self) -> str:
+        return f'path : "{self.path}", ' \
+               f'completed_adb_process : [{self.completed_adb_process.__str__()}]"'
+
+    def __repr__(self) -> str:
+        return self.__str__()

--- a/adb_pywrapper/pull_result.py
+++ b/adb_pywrapper/pull_result.py
@@ -1,6 +1,6 @@
 import os
 
-from adb_pywrapper import AdbResult
+from adb_pywrapper.adb_result import AdbResult
 
 
 class PullResult:

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,12 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(
-    name="adb-pywrapper",
-    version="1.0.0",
-    description="adb-pywrapper facilitates seamless interaction with Android devices using the Android Debug Bridge (ADB) "
+    name="adb_pywrapper",
+    version="1.0.1",
+    packages=find_packages(),
+    test_suite="test",
+
+    description="adb_pywrapper facilitates seamless interaction with Android devices using the Android Debug Bridge (ADB) "
                 "directly within Python scripts.",
     long_description=f"{open('README.md').read()}",
     long_description_content_type="text/markdown",
@@ -11,6 +14,5 @@ setup(
     author_email="netherlandsforensicinstitute@users.noreply.github.com",
     url="https://github.com/NetherlandsForensicInstitute/adb-pywrapper",
     licence="EUPL-1.2",
-    py_modules=["adb-pywrapper", "adb_init"],
-    test_suite="test",
 )
+

--- a/test/test_adb_pywrapper.py
+++ b/test/test_adb_pywrapper.py
@@ -1,9 +1,7 @@
 import os.path
 import subprocess
 import unittest
-from unittest.mock import patch, MagicMock, Mock
-
-from parameterized import parameterized
+from unittest.mock import patch, Mock
 
 from adb_pywrapper import AdbResult, AdbDevice
 

--- a/test/test_adb_pywrapper.py
+++ b/test/test_adb_pywrapper.py
@@ -3,7 +3,8 @@ import subprocess
 import unittest
 from unittest.mock import patch, Mock
 
-from adb_pywrapper import AdbResult, AdbDevice
+from adb_pywrapper.adb_device import AdbDevice
+from adb_pywrapper.adb_result import AdbResult
 
 PROCESS = subprocess.run('echo hello', shell=True, capture_output=True)
 MOCK_SUCCESSFULLY_PULLED_FILE = ['abc.apk', 'bla.jpg']
@@ -319,7 +320,7 @@ class TestAdb(unittest.TestCase):
         self.assertFalse(result.success)
         self.assertIn('Invalid command', result.stderr)
 
-    @patch('adb_pywrapper.AdbDevice._snapshot_command')
+    @patch('adb_pywrapper.adb_device.AdbDevice._snapshot_command')
     def test_emulator_snapshots_list(self, mock_snapshot_command):
         # Test emulator_snapshots_list function
         snapshot_list_output = """List of snapshots present on all disks:
@@ -334,8 +335,8 @@ OK
         mock_snapshot_command.assert_called_once_with('list')
         self.assertEqual(result, ['snap_2023-11-23_13-13-02', 'snap_2023-12-05_12-56-56'])
 
-    @patch('adb_pywrapper.AdbDevice._snapshot_exists')
-    @patch('adb_pywrapper.AdbDevice._snapshot_command')
+    @patch('adb_pywrapper.adb_device.AdbDevice._snapshot_exists')
+    @patch('adb_pywrapper.adb_device.AdbDevice._snapshot_command')
     def test_emulator_snapshot_load_existing(self, mock_snapshot_command, mock_snapshot_exists):
         # Test emulator_snapshot_load function with an existing snapshot
         mock_snapshot_exists.return_value = True
@@ -346,7 +347,7 @@ OK
         mock_snapshot_exists.assert_called_once_with('snapshot1')
         mock_snapshot_command.assert_called_once_with('load', 'snapshot1')
 
-    @patch('adb_pywrapper.AdbDevice._snapshot_exists')
+    @patch('adb_pywrapper.adb_device.AdbDevice._snapshot_exists')
     def test_emulator_snapshot_load_non_existing(self, mock_snapshot_exists):
         # Test emulator_snapshot_load function with a non-existing snapshot
         mock_snapshot_exists.return_value = False
@@ -356,8 +357,8 @@ OK
         mock_snapshot_exists.assert_called_once_with('non_existing_snapshot')
         self.assertFalse(result.success)
 
-    @patch('adb_pywrapper.AdbDevice._snapshot_exists')
-    @patch('adb_pywrapper.AdbDevice._snapshot_command')
+    @patch('adb_pywrapper.adb_device.AdbDevice._snapshot_exists')
+    @patch('adb_pywrapper.adb_device.AdbDevice._snapshot_command')
     def test_emulator_snapshot_save(self, mock_snapshot_command, mock_snapshot_exists):
         # Test emulator_snapshot_save function
         mock_snapshot_exists.return_value = False
@@ -368,9 +369,9 @@ OK
         mock_snapshot_exists.assert_called_once_with('snapshot1')
         mock_snapshot_command.assert_called_once_with('save', 'snapshot1')
 
-    @patch('adb_pywrapper.AdbDevice.emulator_snapshots_list', return_value=['snapshot1', 'snapshot2'])
-    @patch('adb_pywrapper.AdbDevice._snapshot_exists')
-    @patch('adb_pywrapper.AdbDevice._snapshot_command')
+    @patch('adb_pywrapper.adb_device.AdbDevice.emulator_snapshots_list', return_value=['snapshot1', 'snapshot2'])
+    @patch('adb_pywrapper.adb_device.AdbDevice._snapshot_exists')
+    @patch('adb_pywrapper.adb_device.AdbDevice._snapshot_command')
     def test_emulator_snapshot_delete(self, mock_snapshot_command, mock_snapshot_exists, mock_emulator_snapshots_list):
         # Test emulator_snapshot_delete function
         mock_snapshot_exists.return_value = True  # Existing snapshots


### PR DESCRIPTION
The package version 1.0.0 from PyPi could not be installed. This was due to the code not being organized in a package. The following was done to fix the issue:

-     Create a Python package adb_pywrapper (note the underscore, a dash will not work)
-     move adb-pywrapper.py to this package
-     move the contents of adb_init.py to the package init
-     improve the setup.py to find the package
-     refactor the contents of adb_pywrapper.py so the imports are clean
-     adjust the README to match the correct imports
