### PR TITLE
8: Implemented optionaly specified wait time for wait_for_device functionality

### DIFF
--- a/adb_pywrapper/adb_device.py
+++ b/adb_pywrapper/adb_device.py
@@ -92,12 +92,14 @@ class AdbDevice:
             result.success = False
         return result
 
-    def wait_for_device(self) -> AdbResult:
+    def wait_for_device(self, wait_time: Optional[int] = 120) -> AdbResult:
         """
-        Waits for a maximum of 120 seconds until the Android Debug Bridge with the device is available.
+        Waits for a specified amount of seconds or the default 120 seconds until
+        the Android Debug Bridge with the device is available.
+        :param wait_time: amount of seconds to wait for device
         :return: AdbResult containing the completed process of `adb wait-for-device`
         """
-        return self._command('wait-for-device', 120)
+        return self._command('wait-for-device', wait_time)
 
     def shell(self, command: str) -> AdbResult:
         """


### PR DESCRIPTION
I've implemented an optional 'wait_time' variable so the user can specify how long to wait before timing out when waiting for a connection to the device to be established.
The default is still 120 seconds as it was before.

Sidenote, the way timeout is implemented means it will only work on Linux machines since it uses the bash 'timeout' function. I've tried to implement this in a different way so it would be cross platform and managed by python itself by using the subprocess timeout but this does not work since for the execution of commands we are connected to a pipe https://stackoverflow.com/questions/50338959/subprocess-run-isnt-timing-out-even-though-timeout-is-specified
If we ever want the wrapper to be cross platform that's something to look into but changes to this now will probably result in unexpected behavior since we would be changing the adb_command functionality